### PR TITLE
assume that other modules are from the forge

### DIFF
--- a/lib/librarian/puppet/simple/iterator.rb
+++ b/lib/librarian/puppet/simple/iterator.rb
@@ -18,7 +18,9 @@ module Librarian
             @modules[:tarball] ||= []
             @modules[:tarball].push(options.merge(:name => module_name))
           else
-            abort('only the :git and :tarball providers are currently supported')
+            @modules[:forge] ||= []
+            @modules[:forge].push(options.merge(:name => module_name))
+            #abort('only the :git and :tarball providers are currently supported')
           end
         end
 


### PR DESCRIPTION
this commit allows files to be parsed even if
they have non github sources.

These repos will not be installed, but it will
no longer cause everything to blow up.
