### PR TITLE
Skip existing modules on install

### DIFF
--- a/lib/librarian/puppet/simple/installer.rb
+++ b/lib/librarian/puppet/simple/installer.rb
@@ -25,19 +25,26 @@ module Librarian
 
             print_verbose "\n##### processing module #{repo[:name]}..."
 
-            case
-            when repo[:git]
-              install_git module_path, repo[:name], repo[:git], repo[:ref]
-            when repo[:tarball]
-              install_tarball module_path, repo[:name], repo[:tarball]
+            module_dir = File.join(module_path, repo[:name])
+
+            unless File.exists?(module_dir)
+              case
+              when repo[:git]
+                install_git module_path, repo[:name], repo[:git], repo[:ref]
+              when repo[:tarball]
+                install_tarball module_path, repo[:name], repo[:tarball]
+              else
+                abort('only the :git and :tarball provider are currently supported')
+              end
             else
-              abort('only the :git and :tarball provider are currently supported')
+              print_verbose "\nModule #{repo[:name]} already installed in #{module_path}"
             end
           end
         end
 
         private
 
+        # installs sources that are git repos
         def install_git(module_path, module_name, repo, ref = nil)
           module_dir = File.join(module_path, module_name)
 

--- a/spec/functional/install_spec.rb
+++ b/spec/functional/install_spec.rb
@@ -51,5 +51,25 @@ describe "Functional - Install" do
       status.should == 0
       output.should include('##### processing module apache')
     end
+
+    describe 'when modules are already installed' do
+      temp_directory = nil
+
+      before :each do
+        temp_directory = Dir.mktmpdir
+        Dir.entries(temp_directory).should =~ ['.', '..']
+        FileUtils.touch File.join(temp_directory, 'apache')
+        Dir.entries(temp_directory).should =~ ['.', '..', 'apache']
+      end
+
+      it 'without clean it should only install ntp' do
+        output, status = execute_captured("bin/librarian-puppet install --verbose --path=#{temp_directory} --puppetfile=spec/fixtures/Puppetfile")
+        status.should == 0
+        output.should include('Module apache already installed')
+        Dir.entries(temp_directory).should =~ ['.', '..', 'apache', 'ntp']
+      end
+
+    end
   end
+
 end


### PR DESCRIPTION
Currently librarian-puppet-simple fails when any module
already exists with a stack trace. This commit changes this
behavior so that it will skip that module and continue processing.
