### PR TITLE
Add update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Iterates through your Puppetfile and installs git sources. At the moment the sup
   librarian-puppet install [--verbose] [--clean] [--path] [--puppetfile]
 ```
 
+### Update
+Iterates through your Puppetfile and updates git sources. If a SHA-1 hash is specified in the `:ref`, the module will not be updated.
+
+Supported options are:<br/>
+<li>`--verbose` display progress messages</li>
+<li>`--path` override the default `./modules` where modules will be installed</li>
+<li> `--puppetfile` override the default `./Puppetfile` used to find the modules</li>
+
+```
+  librarian-puppet update [--verbose] [--path] [--puppetfile]
+```
+
 ## Puppetfile
 The processed Puppetfile may contain two different types of modules, `git` and `tarball`. The `git` option accepts an optional `ref` parameter.
 

--- a/spec/fixtures/Puppetfile
+++ b/spec/fixtures/Puppetfile
@@ -1,6 +1,13 @@
-mod "puppetlabs/ntp",
-    :git => "git://github.com/puppetlabs/puppetlabs-ntp.git",
-    :ref => "99bae40f225db0dd052efbf1d4078a21f0333331"
+mod 'puppetlabs/ntp',
+    :git => 'git://github.com/puppetlabs/puppetlabs-ntp.git',
+    :ref => '99bae40f225db0dd052efbf1d4078a21f0333331'
 
-mod "apache",
-    :tarball => "https://forge.puppetlabs.com/puppetlabs/apache/0.6.0.tar.gz"
+mod 'apache',
+    :tarball => 'https://forge.puppetlabs.com/puppetlabs/apache/0.6.0.tar.gz'
+
+mod 'ghoneycutt/testlps',
+  :git => 'git://github.com/ghoneycutt/testlps.git'
+
+mod 'ghoneycutt/dnsclient',
+  :git => 'git://github.com/ghoneycutt/puppet-module-dnsclient.git',
+  :ref => 'v3.0.4'


### PR DESCRIPTION
This commit gives the ability to run with an update command which will
only update git repo's that do not have a SHA-1 hash as the ref.
