### PR TITLE
Disallow duplicates

### DIFF
--- a/lib/librarian/puppet/simple/iterator.rb
+++ b/lib/librarian/puppet/simple/iterator.rb
@@ -13,14 +13,14 @@ module Librarian
 
           case
           when options[:git]
-            @modules[:git] ||= []
-            @modules[:git].push(options.merge(:name => module_name, :full_name => full_name))
+            @modules[:git] ||= {}
+            @modules[:git][module_name] = options.merge(:name => module_name, :full_name => full_name)
           when options[:tarball]
-            @modules[:tarball] ||= []
-            @modules[:tarball].push(options.merge(:name => module_name, :full_name => full_name))
+            @modules[:tarball] ||= {}
+            @modules[:tarball][module_name] = options.merge(:name => module_name, :full_name => full_name)
           else
-            @modules[:forge] ||= []
-            @modules[:forge].push(options.merge(:name => module_name, :full_name => full_name))
+            @modules[:forge] ||= {}
+            @modules[:forge][module_name] = options.merge(:name => module_name, :full_name => full_name)
             #abort('only the :git and :tarball providers are currently supported')
           end
         end
@@ -36,7 +36,7 @@ module Librarian
         # iterate through all modules
         def each_module(&block)
           (@modules || {}).each do |type, repos|
-            (repos || []).each do |repo|
+            (repos || {}).values.each do |repo|
               yield repo
             end
           end
@@ -45,7 +45,7 @@ module Librarian
         # loop over each module of a certain type
         def each_module_of_type(type, &block)
           abort("undefined type #{type}") unless [:git, :tarball].include?(type)
-          ((@modules || {})[type] || []).each do |repo|
+          ((@modules || {})[type] || {}).values.each do |repo|
             yield repo
           end
         end


### PR DESCRIPTION
This commit ensures that multiple modules matching the
same name cannot be simultaneously installed.

The last one specified will win. This allows Puppetfiles
to refer to other Puppetfiles via eval where you can always
trust that the later reffered to file will win.
