### PR TITLE
update support for new repos

### DIFF
--- a/lib/librarian/puppet/simple/cli.rb
+++ b/lib/librarian/puppet/simple/cli.rb
@@ -43,17 +43,21 @@ module Librarian
           @custom_module_path = options[:path]
           eval(File.read(File.expand_path(options[:puppetfile])))
           each_module_of_type(:git) do |repo|
-            Dir.chdir(File.join(module_path, repo[:name])) do
-              remote = repo[:git]
-              # if no ref is given, assume master
-              branch = repo[:ref] || 'master'
-              if branch =~ /^origin\/(.*)$/
-                branch = $1
+            if Dir.exists?(File.join(module_path, repo[:name]))
+              Dir.chdir(File.join(module_path, repo[:name])) do
+                remote = repo[:git]
+                # if no ref is given, assume master
+                branch = repo[:ref] || 'master'
+                if branch =~ /^origin\/(.*)$/
+                  branch = $1
+                end
+                co_cmd     = 'git checkout FETCH_HEAD'
+                update_cmd = "git fetch #{repo[:git]} #{branch} && #{co_cmd}"
+                print_verbose "\n\n#{repo[:name]} -- #{update_cmd}"
+                git_pull_cmd = system_cmd(update_cmd)
               end
-              co_cmd     = 'git checkout FETCH_HEAD'
-              update_cmd = "git fetch #{repo[:git]} #{branch} && #{co_cmd}"
-              print_verbose "\n\n#{repo[:name]} -- #{update_cmd}"
-              git_pull_cmd = system_cmd(update_cmd)
+            else
+              install_git module_path, repo[:name], repo[:git], repo[:ref]
             end
           end
         end


### PR DESCRIPTION
in some cases, the update command needs to install new repos
from scratch. This is to support the case where you need to
use librarian-puppet to update a cache by adding a new repo.

this code ensures that update will run install in the case
where the target directory does not already exist.