### PR TITLE
update functionality is fixed

### DIFF
--- a/lib/librarian/puppet/simple/cli.rb
+++ b/lib/librarian/puppet/simple/cli.rb
@@ -51,8 +51,8 @@ module Librarian
                 if branch =~ /^origin\/(.*)$/
                   branch = $1
                 end
-                co_cmd     = 'git checkout FETCH_HEAD'
-                update_cmd = "git fetch #{repo[:git]} #{branch} && #{co_cmd}"
+                co_cmd     = "git checkout #{branch}"
+                update_cmd = "git fetch --all && #{co_cmd}"
                 print_verbose "\n\n#{repo[:name]} -- #{update_cmd}"
                 git_pull_cmd = system_cmd(update_cmd)
               end


### PR DESCRIPTION
This change allows the update functionality to work with any kind of :ref values, let it be a git commit hash, a branch name or a tag name.