### PR TITLE
Change the fetch procedure of the installer

### DIFF
--- a/lib/librarian/puppet/simple/installer.rb
+++ b/lib/librarian/puppet/simple/installer.rb
@@ -53,7 +53,10 @@ module Librarian
             system_cmd("git clone #{repo} #{module_name}")
             Dir.chdir(module_dir) do
               system_cmd('git branch -r')
-              system_cmd("git checkout #{ref}") if ref
+              if ref
+                system_cmd("git fetch origin #{ref}")
+                system_cmd('git checkout FETCH_HEAD')
+              end
             end
           end
         end


### PR DESCRIPTION
The installer uses checkout to switch to the specified branch.
This method usually works, but is not compatible with Gerrit's
refs/changes/\* branches. Using "git fetch origin $ref" and
then "git checkout FETCH_HEAD" works with both normal and
Gerrit branches and is already being used for the "update"
action.
