### PR TITLE
Update thor version

### DIFF
--- a/librarian-puppet-simple.gemspec
+++ b/librarian-puppet-simple.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency "thor", "~> 0.15"
+  s.add_dependency "thor", [">= 0.15", "< 2.0.0"]
 
   s.add_development_dependency "rspec", "~> 2.13"
   s.add_development_dependency "rake", "~> 12.3.3"


### PR DESCRIPTION
Allow the usage of newer versions of thor otherwise this gem might block other applications when bundling together.